### PR TITLE
Use tag based url

### DIFF
--- a/openshift/pipeline-latest-release.sh
+++ b/openshift/pipeline-latest-release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 MAX_SHIFT=2
-STABLE_RELEASE_URL='https://raw.githubusercontent.com/openshift/tektoncd-pipeline/release-${version}/openshift/release/tektoncd-pipeline-${version}.yaml'
+STABLE_RELEASE_URL='https://raw.githubusercontent.com/openshift/tektoncd-pipeline/${version}/openshift/release/tektoncd-pipeline-${version}.yaml'
 
 function get_version {
     local shift=${1} # 0 is latest, increase is the version before etc...


### PR DESCRIPTION
This will change the url to tag based from
branch based to fetch the pipeline release
yaml as the branch name and tag name can
be different like in case of beta release
we have branch name as v0.11.x and
tags as v0.11.0-rc2 and v0.11.0