### PR TITLE
Update release notes for triggers

### DIFF
--- a/openshift/release/release-notes.md
+++ b/openshift/release/release-notes.md
@@ -7,11 +7,6 @@
 This PR will add a CEL function named parseYAML that can parse a YAML string into a map of strings to dynamic values
 Syntax: .parseYAML() -> map<string, dyn>
 
-* Expose the incoming request URL to CEL expressions ([#647](https://github.com/tektoncd/triggers/pull/647))
-
-This adds a requestURL key to the CEL expression context.
-For example, requestURL.parseURL().path would get the path of the incoming request URL.
-
 * Improve the error from the context evaluation ([#646](https://github.com/tektoncd/triggers/pull/646))
 
 Improve the error messages around parsing CEL expressions.
@@ -48,14 +43,9 @@ catch obvious syntax issues like this one.
 * Pass url through ([#657](https://github.com/tektoncd/triggers/pull/657))
 Fix a bug in the sink where is not passing the URL through to the incoming requests.
 
-* Fix install links for nginx ingress for GKE ([#685](https://github.com/tektoncd/triggers/pull/685))
-* Fix typo in README.md of getting started ([#688](https://github.com/tektoncd/triggers/pull/688))
 * Fix triggertemplate validation to validate missing spec field ([#691](https://github.com/tektoncd/triggers/pull/691))
-* Fix Spelling Mistake in TestCase ([#683](https://github.com/tektoncd/triggers/pull/683))
 
 ## Misc :hammer:
-* Change token to secret in gitlab example ([#659](https://github.com/tektoncd/triggers/pull/659))
-* Fix License copyright year ([#655](https://github.com/tektoncd/triggers/pull/655))
 * Use sets.NewString instead of map[string]struct{} ([#663](https://github.com/tektoncd/triggers/pull/663))
 * Update to pipeline knative 0.15 ([#661](https://github.com/tektoncd/triggers/pull/661))
 * Update tektoncd/pipeline to v0.14.2 ([#684](https://github.com/tektoncd/triggers/pull/684))
@@ -65,9 +55,7 @@ Fix a bug in the sink where is not passing the URL through to the incoming reque
 * Add cel filter for pull request actions in github example ([#637](https://github.com/tektoncd/triggers/pull/637))
 * Update docs and examples to use ref instead of name for bindings ([#645](https://github.com/tektoncd/triggers/pull/645))
 * Add EventListener Response in the Doc ([#664](https://github.com/tektoncd/triggers/pull/664))
-* Replace old Release docs in favor of a cheat sheet ([#670](https://github.com/tektoncd/triggers/pull/670))
 * Remove unused Ref from EventListenerTrigger ([#677](https://github.com/tektoncd/triggers/pull/677))
-* Prevent double-logging of interceptor errors ([#689](https://github.com/tektoncd/triggers/pull/689))
 
 ## How to upgrade from v0.6.1 :up_arrow:
 1. Change any $(params) to $(tt.params) in TriggerTemplate
@@ -97,11 +85,6 @@ Error from server (BadRequest): error when creating "STDIN": admission webhook "
 This PR helps to specify TriggerCRD object inside the Eventlistener spec as a reference using triggerRef field,
 So this way user can create TriggerCRD separately and bind it inside Eventlistener spec.
 
-* Migrate reconcilers to use gen reconcilers ([#733](https://github.com/tektoncd/triggers/pull/733))
-
-PR uses genreconciler from knative/pkg to reduce boilerplate code which was required for writing reconciler.
-Also triggers reconciler now emits K8s events on reconciliation failures.
-
 * Add validation and default for TriggerCRD object ([#738](https://github.com/tektoncd/triggers/pull/738))
 
 This PR adds the validation and defaults around TriggerCRD.
@@ -113,54 +96,18 @@ This PR adds the validation and defaults around TriggerCRD.
 The optional EventListenerTrigger based level of authentication for creating Tekton object has had its ServiceAccount reference changed from an ObjectReference to a string ServiceAccountName, effectively enforcing that the ServiceAccount be in the same namespace as the EventListenerTrigger.
 
 ## Fixes :bug:
-* Fix Incorrect number of response for Forbidden error ([#673](https://github.com/tektoncd/triggers/pull/673))
-* Use Kaniko instead of img in the tutorial to fix permission issue ([#701](https://github.com/tektoncd/triggers/pull/701))
-* Cleanup Reconciler Tests in order to pick up Genreconciler updates ([#706](https://github.com/tektoncd/triggers/pull/706))
 * Fix update deployment when there is a change in replicas ([#715](https://github.com/tektoncd/triggers/pull/715))
 * Add basic syntactical parsing of CEL filters and expressions ([#745](https://github.com/tektoncd/triggers/pull/745))
 
 Perform simple syntax checking of CEL filter and overlays in the Webhook validator, perfunctory syntax validation of the expressions in the interceptor but it won't detect logical errors (expressions that rely on JSON bodies).
 
-## Misc :hammer:
-* Add TestBuilder for TriggerCRD ([#680](https://github.com/tektoncd/triggers/pull/680))
-* Use ko:// prefix for all images ([#692](https://github.com/tektoncd/triggers/pull/692))
-
-Adds ko:// scheme to images used by ko (dev only)
-
-* Fix GitHub example bindings ([#694](https://github.com/tektoncd/triggers/pull/694))
-* Add interceptor to processTriggerSpec ([#695](https://github.com/tektoncd/triggers/pull/695))
-
-This is an experimental feature and its a part of creating CLI for TriggerRun. It contains the parts that add an interceptor to processTriggerSpec, updates readHTTP to print out resources, and trigger function to run Trigger CLI.
-
-* Fix URL in Release Cheat Sheet ([#696](https://github.com/tektoncd/triggers/pull/696))
-* Change tekton.dev to triggers.tekton.dev for e2e Tests ([#702](https://github.com/tektoncd/triggers/pull/702))
-* Add createResource in TriggerRun CLI ([#708](https://github.com/tektoncd/triggers/pull/708))
-
-This is also an experimental feature for TriggerRun CLI
-
-* Add khrm@ as an OWNER ([#710](https://github.com/tektoncd/triggers/pull/710))
-* Mark some command tests as end-to-end ([#719](https://github.com/tektoncd/triggers/pull/719))
-* Use another NodeSelector value in EventListener tests ([#720](https://github.com/tektoncd/triggers/pull/720))
-
-This change helps to run e2e on non amd64 architecture (s390x, ppc64le, etc).
-
-* Add TriggerCRD object to Known Type for schema ([#732](https://github.com/tektoncd/triggers/pull/732))
-* Change Eventlistener Trigger Binding and Trigger Template type to TriggerSpec ([#740](https://github.com/tektoncd/triggers/pull/740))
-
 ## Docs :book:
-* Fix release cheat sheet doc ([#693](https://github.com/tektoncd/triggers/pull/693))
-* Add namespace to the commands in Nginx ingress doc ([#698](https://github.com/tektoncd/triggers/pull/698))
-* Add links to versioned docs for v0.7.0 ([#703](https://github.com/tektoncd/triggers/pull/703))
 * Update eventlistener doc to include eventlistener responsibility ([#721](https://github.com/tektoncd/triggers/pull/721))
 
 Added information about the responsibility of Eventlistener.
 
-* Update README for Bitbucket example ([#724](https://github.com/tektoncd/triggers/pull/724))
 * Update triggertemplate doc and example to use tt.params ([#725](https://github.com/tektoncd/triggers/pull/725))
 * Clarify Bitbucket and Github HMAC generation instruction in example ([#728](https://github.com/tektoncd/triggers/pull/728))
-* Updates to the happy path readme(s) ([#730](https://github.com/tektoncd/triggers/pull/730))
-* Remove vendor specific cluster setup instructions ([#739](https://github.com/tektoncd/triggers/pull/739))
-* Update link to happy path ([#742](https://github.com/tektoncd/triggers/pull/742))
 * Update pull request template for release-note ([#743](https://github.com/tektoncd/triggers/pull/743))
 
 ## How to upgrade from v0.7.0 :up_arrow:
@@ -172,10 +119,6 @@ kubectl apply -f https://storage.googleapis.com/tekton-releases/triggers/previou
 # Tekton Triggers v0.8.1
 
 ## Fixes :bug:
-* Handle validation, defaults and working behavior for Replicas ([#751](https://github.com/tektoncd/triggers/pull/751))
-
-If provided replicas value as 0 as part of EventListener spec then a default value 1 will be set by webhook.
-
 * Merge annotations before propagation ([#753](https://github.com/tektoncd/triggers/pull/753))
 
 Triggers no longer overwrites annotations set on the underlying deployment and service objects.
@@ -183,9 +126,6 @@ Triggers no longer overwrites annotations set on the underlying deployment and s
 * Add a Idle Timeout for EventListener sink ([#755](https://github.com/tektoncd/triggers/pull/755))
 
 EventListeners close idle connections after 120 seconds.
-
-## Docs :book:
-* Add release links to versioned docs for v0.8.0 ([#749](https://github.com/tektoncd/triggers/pull/749))
 
 ## How to upgrade from v0.8.0 :up_arrow:
 ```text


### PR DESCRIPTION
Removed few release notes information which are not needed to expose to end user
also handled review comments from https://github.com/openshift/tektoncd-triggers/pull/276
/cc @khrm @vdemeester 