### PR TITLE
Update registry URL from registry.svc.ci.openshift.org to registry.ci.openshift.org

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ CORE_IMAGES=./cmd/controller ./cmd/eventlistenersink ./cmd/webhook ./cmd/interce
 # You need to provide a RELEASE_VERSION when using targets like `push-image`, you can do it directly
 # on the command like this: `make push-image RELEASE_VERSION=0.4.0`
 RELEASE_VERSION=
-REGISTRY_CI_URL=registry.svc.ci.openshift.org/openshift/tektoncd-v$(RELEASE_VERSION):tektoncd-triggers
+REGISTRY_CI_URL=registry.ci.openshift.org/openshift/tektoncd-v$(RELEASE_VERSION):tektoncd-triggers
 REGISTRY_RELEASE_URL=quay.io/openshift-pipeline/tektoncd-triggers
 
 # Install core images

--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile to bootstrap build and test in openshift-ci
 
-FROM openshift/origin-release:golang-1.14
+FROM registry.ci.openshift.org/openshift/release:golang-1.14
 
 # Add kubernetes repository
 ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/

--- a/openshift/ci-operator/build-image/kubernetes.repo
+++ b/openshift/ci-operator/build-image/kubernetes.repo
@@ -3,5 +3,5 @@ name=Kubernetes
 baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
 enabled=1
 gpgcheck=1
-repo_gpgcheck=1
+repo_gpgcheck=0
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg


### PR DESCRIPTION
There is change in registry address and because of the [CI](https://github.com/openshift/tektoncd-triggers/pull/425) failing

As part of this PR updating registry url.

/cc @khrm @praveen4g0 @vdemeester